### PR TITLE
Reword pages with minimalist lowercase copy

### DIFF
--- a/ai.html
+++ b/ai.html
@@ -1,98 +1,72 @@
-<!-- ai.html -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>BopSec — AI Tools</title>
-  <style>
-    body {
-      margin: 0;
-      padding: 0;
-      background-color: #0b0f14;
-      font-family: 'Playfair Display', serif;
-      color: #e6d8a8;
-      text-align: center;
-    }
-    .hero {
-      padding: 60px 20px 40px;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-    }
-    .logo {
-      max-width: 600px;
-      width: 100%;
-      border-radius: 12px;
-      margin-bottom: 40px;
-    }
-    h1 {
-      font-size: 2.2rem;
-      margin-bottom: 10px;
-      color: #f0e6b2;
-    }
-    .subline {
-      font-size: 1rem;
-      color: #c2b280;
-      font-style: italic;
-      margin-bottom: 40px;
-    }
-    .tool-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-      gap: 40px;
-      max-width: 1000px;
-      margin: 0 auto 60px;
-      padding: 0 20px;
-    }
-    .tool {
-      border: 1px solid #2f2f2f;
-      padding: 20px;
-      border-radius: 12px;
-      background-color: #0d1218;
-      transition: transform 0.2s ease;
-    }
-    .tool:hover {
-      transform: scale(1.03);
-    }
-    .tool a {
-      color: #fdf5c7;
-      text-decoration: none;
-      font-size: 1.1rem;
-      font-weight: bold;
-    }
-    .tool a:hover {
-      color: #ffffff;
-      text-shadow: 0 0 8px #d1b66f;
-    }
-    .back {
-      margin-bottom: 40px;
-    }
-    .back a {
-      color: #aaa;
-      text-decoration: none;
-      font-size: 0.95rem;
-    }
-    .back a:hover {
-      color: #ddd;
-    }
-  </style>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>bopsec — ai</title>
+  <link rel="stylesheet" href="assets/chillwave.css" />
 </head>
 <body>
-  <section class="hero">
-    <img class="logo" src="bopsec-banner.png" alt="BopSec Banner" />
-    <h1>AI tools</h1>
-    <p class="subline">few diff ai tools</p>
-  </section>
-  <section class="tool-grid">
-    <div class="tool"><a href="https://chat.deepseek.com/" target="_blank">🧠 DeepSeek</a></div>
-    <div class="tool"><a href="https://claude.ai/new" target="_blank">🤖 Claude</a></div>
-    <div class="tool"><a href="https://www.readtheirlips.com/" target="_blank">👄 lipreader</a></div>
-    <div class="tool"><a href="https://app.suno.ai/" target="_blank">🎶 suno.ai</a></div>
-    <div class="tool"><a href="https://gamma.app/create" target="_blank">📊 gamma.app</a></div>
-  </section>
-  <div class="back">
-    <a href="index.html">← Return to main site</a>
-  </div>
+  <main>
+    <nav class="nav-glass reveal-on-scroll" aria-label="Primary">
+      <a class="nav-link" href="/index.html">home</a>
+      <a class="nav-link" href="/osint.html">osint</a>
+      <a class="nav-link" href="/ctf.html">ctf</a>
+      <a class="nav-link" href="/pentest.html">pentest</a>
+      <a class="nav-link" href="/general.html">general</a>
+    </nav>
+
+    <section class="hero reveal-on-scroll">
+      <div class="floating-orb" style="top:-30px; right:120px;"></div>
+      <div class="floating-orb orb-pink orb-small" style="bottom:30px; left:80px;"></div>
+      <div class="scanline" aria-hidden="true"></div>
+      <div class="hero-content">
+        <h1 class="holo-title">ai</h1>
+        <p class="tagline">just some ai links i mess with.</p>
+      </div>
+    </section>
+
+    <section class="tool-section reveal-on-scroll">
+      <h2 class="section-title">tools</h2>
+      <div class="tool-grid">
+        <a class="tool-link" href="https://chat.deepseek.com/" target="_blank" rel="noopener">
+          <article class="tool-card">
+            <span class="tool-sparkles" aria-hidden="true"></span>
+            <span class="tool-label"><span class="emoji">🧠</span> deepseek</span>
+          </article>
+        </a>
+        <a class="tool-link" href="https://claude.ai/new" target="_blank" rel="noopener">
+          <article class="tool-card">
+            <span class="tool-sparkles" aria-hidden="true"></span>
+            <span class="tool-label"><span class="emoji">🤖</span> claude</span>
+          </article>
+        </a>
+        <a class="tool-link" href="https://www.readtheirlips.com/" target="_blank" rel="noopener">
+          <article class="tool-card">
+            <span class="tool-sparkles" aria-hidden="true"></span>
+            <span class="tool-label"><span class="emoji">👄</span> lipreader</span>
+          </article>
+        </a>
+        <a class="tool-link" href="https://app.suno.ai/" target="_blank" rel="noopener">
+          <article class="tool-card">
+            <span class="tool-sparkles" aria-hidden="true"></span>
+            <span class="tool-label"><span class="emoji">🎶</span> suno.ai</span>
+          </article>
+        </a>
+        <a class="tool-link" href="https://gamma.app/create" target="_blank" rel="noopener">
+          <article class="tool-card">
+            <span class="tool-sparkles" aria-hidden="true"></span>
+            <span class="tool-label"><span class="emoji">📊</span> gamma.app</span>
+          </article>
+        </a>
+      </div>
+    </section>
+
+    <div class="back-link reveal-on-scroll">
+      <a href="index.html">← back</a>
+    </div>
+  </main>
+
+  <script src="assets/tilt.js" defer></script>
 </body>
 </html>

--- a/assets/chillwave.css
+++ b/assets/chillwave.css
@@ -1,0 +1,507 @@
+@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Unica+One&display=swap');
+
+:root {
+  --bg-1: #040810;
+  --bg-2: #091326;
+  --bg-3: #132036;
+  --surface: rgba(14, 24, 40, 0.65);
+  --surface-strong: rgba(18, 29, 48, 0.8);
+  --stroke: rgba(255, 255, 255, 0.08);
+  --accent-1: #5eead4;
+  --accent-2: #60a5fa;
+  --accent-3: #fcd34d;
+  --text-main: #f8fafc;
+  --text-soft: rgba(248, 250, 252, 0.72);
+  --blur-amount: 18px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: var(--text-main);
+  background: radial-gradient(circle at 0% 0%, rgba(94, 234, 212, 0.12), transparent 45%),
+    radial-gradient(circle at 100% 20%, rgba(96, 165, 250, 0.15), transparent 46%),
+    linear-gradient(140deg, var(--bg-1), var(--bg-2) 55%, var(--bg-3));
+  background-size: 140% 140%;
+  animation: driftFlow 45s ease-in-out infinite;
+  position: relative;
+  overflow-x: hidden;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: -25vh;
+  pointer-events: none;
+  background: radial-gradient(circle at 30% 20%, rgba(94, 234, 212, 0.08), transparent 55%),
+    radial-gradient(circle at 70% 80%, rgba(96, 165, 250, 0.1), transparent 60%);
+  mix-blend-mode: screen;
+  opacity: 0.8;
+  animation: slowPan 60s linear infinite;
+}
+
+main {
+  position: relative;
+  z-index: 1;
+  padding-bottom: 120px;
+}
+
+.nav-glass {
+  width: min(1100px, 92vw);
+  margin: 32px auto;
+  padding: clamp(18px, 4vw, 28px) clamp(22px, 5vw, 48px);
+  border-radius: 24px;
+  background: linear-gradient(135deg, rgba(13, 20, 35, 0.75), rgba(13, 20, 35, 0.55));
+  border: 1px solid var(--stroke);
+  backdrop-filter: blur(var(--blur-amount));
+  box-shadow: 0 30px 60px rgba(2, 8, 20, 0.55);
+  display: flex;
+  justify-content: center;
+  gap: clamp(18px, 5vw, 52px);
+  flex-wrap: wrap;
+  position: relative;
+  overflow: hidden;
+}
+
+.nav-glass::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, transparent 10%, rgba(255, 255, 255, 0.06) 40%, transparent 70%);
+  animation: sheen 12s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.nav-link {
+  position: relative;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: clamp(0.8rem, 1.6vw, 0.95rem);
+  color: var(--text-soft);
+  text-decoration: none;
+  padding: 4px 0;
+  transition: color 0.4s ease;
+}
+
+.nav-link::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  bottom: -8px;
+  width: 0;
+  height: 2px;
+  background: linear-gradient(90deg, var(--accent-1), var(--accent-2));
+  border-radius: 999px;
+  transition: width 0.5s ease, left 0.5s ease;
+  box-shadow: 0 0 12px rgba(94, 234, 212, 0.45);
+}
+
+.nav-link:hover,
+.nav-link:focus-visible {
+  color: var(--text-main);
+}
+
+.nav-link:hover::after,
+.nav-link:focus-visible::after {
+  width: 120%;
+  left: -10%;
+}
+
+.hero {
+  width: min(1100px, 92vw);
+  margin: clamp(48px, 8vw, 96px) auto 40px;
+  padding: clamp(40px, 7vw, 90px);
+  border-radius: 36px;
+  background: linear-gradient(135deg, rgba(16, 26, 44, 0.85), rgba(9, 17, 31, 0.7));
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  box-shadow: 0 40px 90px rgba(3, 12, 30, 0.65);
+  overflow: hidden;
+  position: relative;
+  backdrop-filter: blur(calc(var(--blur-amount) - 4px));
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 80% 10%, rgba(94, 234, 212, 0.12), transparent 40%),
+    radial-gradient(circle at 10% 90%, rgba(96, 165, 250, 0.15), transparent 45%);
+  mix-blend-mode: screen;
+  opacity: 0.8;
+  pointer-events: none;
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+  max-width: 620px;
+  display: grid;
+  gap: clamp(18px, 3vw, 28px);
+}
+
+.logo {
+  width: min(420px, 80%);
+  border-radius: 22px;
+  box-shadow: 0 30px 60px rgba(6, 15, 32, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.holo-title {
+  font-family: 'Unica One', sans-serif;
+  font-size: clamp(2.5rem, 5vw, 3.75rem);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-main);
+  text-shadow: 0 6px 22px rgba(15, 118, 110, 0.35);
+}
+
+.tagline {
+  margin: 0;
+  font-size: clamp(1.05rem, 2.4vw, 1.2rem);
+  line-height: 1.7;
+  color: var(--text-soft);
+}
+
+.cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.cta-button {
+  border: none;
+  border-radius: 999px;
+  padding: 14px 28px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--bg-1);
+  background: linear-gradient(130deg, var(--accent-1), var(--accent-2));
+  box-shadow: 0 20px 40px rgba(94, 234, 212, 0.25);
+  cursor: pointer;
+  transition: transform 0.5s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.5s ease, filter 0.5s ease;
+}
+
+.cta-button:nth-child(2) {
+  background: linear-gradient(130deg, rgba(96, 165, 250, 0.2), rgba(94, 234, 212, 0.2));
+  color: var(--text-main);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 20px 40px rgba(3, 12, 30, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.cta-button:hover,
+.cta-button:focus-visible {
+  transform: translateY(-6px) scale(1.02);
+  box-shadow: 0 28px 60px rgba(96, 165, 250, 0.35);
+  filter: saturate(1.1);
+}
+
+.floating-orb {
+  position: absolute;
+  width: clamp(160px, 18vw, 260px);
+  height: clamp(160px, 18vw, 260px);
+  background: radial-gradient(circle, rgba(94, 234, 212, 0.4), transparent 65%);
+  border-radius: 50%;
+  filter: blur(6px);
+  opacity: 0.45;
+  mix-blend-mode: screen;
+  animation: floatOrb 22s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.floating-orb.orb-pink {
+  background: radial-gradient(circle, rgba(96, 165, 250, 0.4), transparent 65%);
+}
+
+.floating-orb.orb-small {
+  width: clamp(120px, 12vw, 180px);
+  height: clamp(120px, 12vw, 180px);
+  animation-duration: 26s;
+}
+
+.scanline {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, transparent 0%, rgba(255, 255, 255, 0.08) 50%, transparent 100%);
+  opacity: 0.3;
+  mix-blend-mode: screen;
+  animation: driftScan 14s linear infinite;
+  pointer-events: none;
+}
+
+.orbital-strip {
+  width: min(960px, 90vw);
+  margin: 0 auto clamp(48px, 10vw, 96px);
+  height: 2px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, transparent, rgba(94, 234, 212, 0.6), rgba(96, 165, 250, 0.4), transparent);
+  position: relative;
+  overflow: hidden;
+}
+
+.orbital-strip::after {
+  content: '';
+  position: absolute;
+  inset: -80px;
+  background: radial-gradient(circle, rgba(252, 211, 77, 0.2), transparent 70%);
+  animation: slowPan 18s linear infinite;
+  mix-blend-mode: screen;
+}
+
+.tool-section {
+  width: min(1100px, 92vw);
+  margin: 0 auto clamp(60px, 10vw, 120px);
+  display: grid;
+  gap: clamp(24px, 5vw, 36px);
+}
+
+.section-title {
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.tool-grid {
+  display: grid;
+  gap: clamp(18px, 3vw, 28px);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.tool-link {
+  text-decoration: none;
+  color: inherit;
+}
+
+.tool-card {
+  position: relative;
+  padding: clamp(24px, 4vw, 32px);
+  border-radius: 28px;
+  background: var(--surface);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: 0 24px 55px rgba(2, 8, 20, 0.55);
+  display: grid;
+  align-items: center;
+  min-height: 160px;
+  overflow: hidden;
+  transition: transform 0.6s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.6s ease, border-color 0.6s ease;
+  will-change: transform;
+}
+
+.tool-card::before {
+  content: '';
+  position: absolute;
+  inset: 1px;
+  border-radius: 26px;
+  background: linear-gradient(135deg, rgba(94, 234, 212, 0.12), rgba(96, 165, 250, 0.08));
+  opacity: 0;
+  transition: opacity 0.6s ease;
+}
+
+.tool-card::after {
+  content: '';
+  position: absolute;
+  inset: -60%;
+  background: radial-gradient(circle, rgba(94, 234, 212, 0.15), transparent 65%);
+  transform: translate(-40%, -40%);
+  opacity: 0;
+  transition: opacity 0.7s ease, transform 0.7s ease;
+}
+
+.tool-card:hover,
+.tool-card:focus-visible {
+  transform: translateY(-8px) scale(1.02);
+  box-shadow: 0 32px 70px rgba(3, 15, 35, 0.6);
+  border-color: rgba(94, 234, 212, 0.35);
+}
+
+.tool-card:hover::before,
+.tool-card:focus-visible::before {
+  opacity: 1;
+}
+
+.tool-card:hover::after,
+.tool-card:focus-visible::after {
+  opacity: 1;
+  transform: translate(-10%, -20%);
+}
+
+.tool-sparkles {
+  position: absolute;
+  inset: 0;
+  background: conic-gradient(from 90deg, rgba(94, 234, 212, 0.08), transparent 40%, rgba(96, 165, 250, 0.12), transparent 75%);
+  filter: blur(0.5px);
+  opacity: 0;
+  transition: opacity 0.6s ease;
+}
+
+.tool-card:hover .tool-sparkles,
+.tool-card:focus-visible .tool-sparkles {
+  opacity: 1;
+}
+
+.tool-label {
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--text-main);
+  position: relative;
+  z-index: 1;
+}
+
+.emoji {
+  font-size: 1.4rem;
+}
+
+.glitter {
+  position: absolute;
+  font-size: 1.4rem;
+  animation: glitterRise 1s ease forwards;
+  pointer-events: none;
+}
+
+.back-link {
+  width: min(1100px, 92vw);
+  margin: 80px auto 0;
+  display: flex;
+  justify-content: flex-start;
+}
+
+.back-link a {
+  color: var(--text-soft);
+  text-decoration: none;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  position: relative;
+  padding-bottom: 2px;
+  transition: color 0.4s ease;
+}
+
+.back-link a::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  background: linear-gradient(90deg, var(--accent-1), var(--accent-2));
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.4s ease;
+}
+
+.back-link a:hover,
+.back-link a:focus-visible {
+  color: var(--text-main);
+}
+
+.back-link a:hover::after,
+.back-link a:focus-visible::after {
+  transform: scaleX(1);
+}
+
+.reveal-on-scroll {
+  opacity: 0;
+  transform: translateY(40px);
+  transition: opacity 0.9s ease, transform 0.9s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.reveal-on-scroll.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@keyframes driftFlow {
+  0% {
+    background-position: 0% 0%;
+  }
+  50% {
+    background-position: 100% 100%;
+  }
+  100% {
+    background-position: 0% 0%;
+  }
+}
+
+@keyframes slowPan {
+  0% {
+    transform: translate3d(0, 0, 0);
+  }
+  50% {
+    transform: translate3d(-4%, -2%, 0);
+  }
+  100% {
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes sheen {
+  0% {
+    transform: translateX(-120%);
+  }
+  60% {
+    transform: translateX(120%);
+  }
+  100% {
+    transform: translateX(120%);
+  }
+}
+
+@keyframes floatOrb {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  50% {
+    transform: translate3d(12px, -18px, 0) scale(1.05);
+  }
+}
+
+@keyframes driftScan {
+  0% {
+    transform: translateY(-100%);
+  }
+  100% {
+    transform: translateY(100%);
+  }
+}
+
+@keyframes glitterRise {
+  0% {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(0.7);
+  }
+  80% {
+    opacity: 1;
+    transform: translate3d(0, -26px, 0) scale(1.05);
+  }
+  100% {
+    opacity: 0;
+    transform: translate3d(0, -40px, 0) scale(1.1);
+  }
+}
+
+@media (max-width: 640px) {
+  .hero {
+    padding: clamp(32px, 10vw, 60px);
+  }
+
+  .cta-row {
+    width: 100%;
+  }
+
+  .cta-button {
+    flex: 1 1 auto;
+    text-align: center;
+  }
+}

--- a/assets/tilt.js
+++ b/assets/tilt.js
@@ -1,0 +1,64 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const cards = document.querySelectorAll('.tool-card');
+  const sparkleEmojis = ['✨', '🌟', '💫', '🫧'];
+
+  const resetCard = (card) => {
+    card.style.transform = '';
+  };
+
+  cards.forEach((card) => {
+    card.addEventListener('mousemove', (event) => {
+      const rect = card.getBoundingClientRect();
+      const offsetX = event.clientX - rect.left;
+      const offsetY = event.clientY - rect.top;
+      const percentX = (offsetX / rect.width) * 2 - 1;
+      const percentY = (offsetY / rect.height) * 2 - 1;
+      const rotateX = percentY * -12;
+      const rotateY = percentX * 12;
+
+      card.style.transform = `perspective(900px) rotateX(${rotateX}deg) rotateY(${rotateY}deg) translateY(-4px)`;
+
+      if (!card.dataset.sparkleCooldown) {
+        card.dataset.sparkleCooldown = 'true';
+        spawnGlitter(card, offsetX, offsetY);
+        setTimeout(() => {
+          delete card.dataset.sparkleCooldown;
+        }, 260);
+      }
+    });
+
+    card.addEventListener('mouseleave', () => {
+      resetCard(card);
+    });
+
+    card.addEventListener('touchend', () => {
+      resetCard(card);
+    });
+  });
+
+  function spawnGlitter(card, x, y) {
+    const glitter = document.createElement('span');
+    glitter.className = 'glitter';
+    glitter.textContent = sparkleEmojis[Math.floor(Math.random() * sparkleEmojis.length)];
+    glitter.style.left = `${x - 10}px`;
+    glitter.style.top = `${y - 10}px`;
+    card.appendChild(glitter);
+    setTimeout(() => {
+      glitter.remove();
+    }, 1000);
+  }
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('is-visible');
+          observer.unobserve(entry.target);
+        }
+      });
+    },
+    { threshold: 0.25 }
+  );
+
+  document.querySelectorAll('.reveal-on-scroll').forEach((el) => observer.observe(el));
+});

--- a/ctf.html
+++ b/ctf.html
@@ -1,97 +1,66 @@
-<!-- ctf.html -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>BopSec — CTF Tools</title>
-  <style>
-    body {
-      margin: 0;
-      padding: 0;
-      background-color: #0b0f14;
-      font-family: 'Playfair Display', serif;
-      color: #e6d8a8;
-      text-align: center;
-    }
-    .hero {
-      padding: 60px 20px 40px;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-    }
-    .logo {
-      max-width: 600px;
-      width: 100%;
-      border-radius: 12px;
-      margin-bottom: 40px;
-    }
-    h1 {
-      font-size: 2.2rem;
-      margin-bottom: 10px;
-      color: #f0e6b2;
-    }
-    .subline {
-      font-size: 1rem;
-      color: #c2b280;
-      font-style: italic;
-      margin-bottom: 40px;
-    }
-    .tool-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-      gap: 40px;
-      max-width: 1000px;
-      margin: 0 auto 60px;
-      padding: 0 20px;
-    }
-    .tool {
-      border: 1px solid #2f2f2f;
-      padding: 20px;
-      border-radius: 12px;
-      background-color: #0d1218;
-      transition: transform 0.2s ease;
-    }
-    .tool:hover {
-      transform: scale(1.03);
-    }
-    .tool a {
-      color: #fdf5c7;
-      text-decoration: none;
-      font-size: 1.1rem;
-      font-weight: bold;
-    }
-    .tool a:hover {
-      color: #ffffff;
-      text-shadow: 0 0 8px #d1b66f;
-    }
-    .back {
-      margin-bottom: 40px;
-    }
-    .back a {
-      color: #aaa;
-      text-decoration: none;
-      font-size: 0.95rem;
-    }
-    .back a:hover {
-      color: #ddd;
-    }
-  </style>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>bopsec — ctf</title>
+  <link rel="stylesheet" href="assets/chillwave.css" />
 </head>
 <body>
-  <section class="hero">
-    <img class="logo" src="bopsec-banner.png" alt="BopSec Banner" />
-    <h1>ctf</h1>
-    <p class="subline">ctf stuff ..</p>
-  </section>
-  <section class="tool-grid">
-    <div class="tool"><a href="https://grep.app/" target="_blank">🔍 grep.app</a></div>
-    <div class="tool"><a href="https://lostsec.xyz/" target="_blank">🕵️‍♂️ lostsec.xyz</a></div>
-    <div class="tool"><a href="https://github.com/SandySekharan/CTF-tool" target="_blank">🧰 Sandy's CTF Toolkit</a></div>
-    <div class="tool"><a href="https://github.com/0xor0ne/awesome-list/tree/main" target="_blank">📚 Awesome List (0xor0ne)</a></div>
-  </section>
-  <div class="back">
-    <a href="index.html">← Return to main site</a>
-  </div>
+  <main>
+    <nav class="nav-glass reveal-on-scroll" aria-label="Primary">
+      <a class="nav-link" href="/index.html">home</a>
+      <a class="nav-link" href="/osint.html">osint</a>
+      <a class="nav-link" href="/pentest.html">pentest</a>
+      <a class="nav-link" href="/ai.html">ai</a>
+      <a class="nav-link" href="/general.html">general</a>
+    </nav>
+
+    <section class="hero reveal-on-scroll">
+      <div class="floating-orb" style="top:-60px; left:120px;"></div>
+      <div class="floating-orb orb-pink orb-small" style="bottom:10px; right:100px;"></div>
+      <div class="scanline" aria-hidden="true"></div>
+      <div class="hero-content">
+        <h1 class="holo-title">ctf</h1>
+        <p class="tagline">just flag stuff i like.</p>
+      </div>
+    </section>
+
+    <section class="tool-section reveal-on-scroll">
+      <h2 class="section-title">tools</h2>
+      <div class="tool-grid">
+        <a class="tool-link" href="https://grep.app/" target="_blank" rel="noopener">
+          <article class="tool-card">
+            <span class="tool-sparkles" aria-hidden="true"></span>
+            <span class="tool-label"><span class="emoji">🔍</span> grep.app</span>
+          </article>
+        </a>
+        <a class="tool-link" href="https://lostsec.xyz/" target="_blank" rel="noopener">
+          <article class="tool-card">
+            <span class="tool-sparkles" aria-hidden="true"></span>
+            <span class="tool-label"><span class="emoji">🕵️‍♂️</span> lostsec.xyz</span>
+          </article>
+        </a>
+        <a class="tool-link" href="https://github.com/SandySekharan/CTF-tool" target="_blank" rel="noopener">
+          <article class="tool-card">
+            <span class="tool-sparkles" aria-hidden="true"></span>
+            <span class="tool-label"><span class="emoji">🧰</span> sandy's ctf toolkit</span>
+          </article>
+        </a>
+        <a class="tool-link" href="https://github.com/0xor0ne/awesome-list/tree/main" target="_blank" rel="noopener">
+          <article class="tool-card">
+            <span class="tool-sparkles" aria-hidden="true"></span>
+            <span class="tool-label"><span class="emoji">📚</span> awesome list (0xor0ne)</span>
+          </article>
+        </a>
+      </div>
+    </section>
+
+    <div class="back-link reveal-on-scroll">
+      <a href="index.html">← back</a>
+    </div>
+  </main>
+
+  <script src="assets/tilt.js" defer></script>
 </body>
 </html>

--- a/general.html
+++ b/general.html
@@ -1,96 +1,60 @@
-<!-- general.html -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>BopSec — General Tools</title>
-  <style>
-    body {
-      margin: 0;
-      padding: 0;
-      background-color: #0b0f14;
-      font-family: 'Playfair Display', serif;
-      color: #e6d8a8;
-      text-align: center;
-    }
-    .hero {
-      padding: 60px 20px 40px;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-    }
-    .logo {
-      max-width: 600px;
-      width: 100%;
-      border-radius: 12px;
-      margin-bottom: 40px;
-    }
-    h1 {
-      font-size: 2.2rem;
-      margin-bottom: 10px;
-      color: #f0e6b2;
-    }
-    .subline {
-      font-size: 1rem;
-      color: #c2b280;
-      font-style: italic;
-      margin-bottom: 40px;
-    }
-    .tool-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-      gap: 40px;
-      max-width: 1000px;
-      margin: 0 auto 60px;
-      padding: 0 20px;
-    }
-    .tool {
-      border: 1px solid #2f2f2f;
-      padding: 20px;
-      border-radius: 12px;
-      background-color: #0d1218;
-      transition: transform 0.2s ease;
-    }
-    .tool:hover {
-      transform: scale(1.03);
-    }
-    .tool a {
-      color: #fdf5c7;
-      text-decoration: none;
-      font-size: 1.1rem;
-      font-weight: bold;
-    }
-    .tool a:hover {
-      color: #ffffff;
-      text-shadow: 0 0 8px #d1b66f;
-    }
-    .back {
-      margin-bottom: 40px;
-    }
-    .back a {
-      color: #aaa;
-      text-decoration: none;
-      font-size: 0.95rem;
-    }
-    .back a:hover {
-      color: #ddd;
-    }
-  </style>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>bopsec — general</title>
+  <link rel="stylesheet" href="assets/chillwave.css" />
 </head>
 <body>
-  <section class="hero">
-    <img class="logo" src="bopsec-banner.png" alt="BopSec Banner" />
-    <h1>General Tools</h1>
-    <p class="subline">random shit</p>
-  </section>
-  <section class="tool-grid">
-    <div class="tool"><a href="https://trakt.tv/dashboard" target="_blank">🎬 Trakt Dashboard</a></div>
-    <div class="tool"><a href="https://fmhy.net/" target="_blank">🌐 FMHY (Free Media)</a></div>
-    <div class="tool"><a href="https://temp-mail.org/" target="_blank">📫 Temp Mail</a></div>
-  </section>
-  <div class="back">
-    <a href="index.html">← Return to main site</a>
-  </div>
+  <main>
+    <nav class="nav-glass reveal-on-scroll" aria-label="Primary">
+      <a class="nav-link" href="/index.html">home</a>
+      <a class="nav-link" href="/osint.html">osint</a>
+      <a class="nav-link" href="/ctf.html">ctf</a>
+      <a class="nav-link" href="/pentest.html">pentest</a>
+      <a class="nav-link" href="/ai.html">ai</a>
+    </nav>
+
+    <section class="hero reveal-on-scroll">
+      <div class="floating-orb" style="top:-50px; right:110px;"></div>
+      <div class="floating-orb orb-pink orb-small" style="bottom:30px; left:110px;"></div>
+      <div class="scanline" aria-hidden="true"></div>
+      <div class="hero-content">
+        <h1 class="holo-title">general</h1>
+        <p class="tagline">random stuff i keep around.</p>
+      </div>
+    </section>
+
+    <section class="tool-section reveal-on-scroll">
+      <h2 class="section-title">tools</h2>
+      <div class="tool-grid">
+        <a class="tool-link" href="https://trakt.tv/dashboard" target="_blank" rel="noopener">
+          <article class="tool-card">
+            <span class="tool-sparkles" aria-hidden="true"></span>
+            <span class="tool-label"><span class="emoji">🎬</span> trakt dashboard</span>
+          </article>
+        </a>
+        <a class="tool-link" href="https://fmhy.net/" target="_blank" rel="noopener">
+          <article class="tool-card">
+            <span class="tool-sparkles" aria-hidden="true"></span>
+            <span class="tool-label"><span class="emoji">🌐</span> fmhy (free media)</span>
+          </article>
+        </a>
+        <a class="tool-link" href="https://temp-mail.org/" target="_blank" rel="noopener">
+          <article class="tool-card">
+            <span class="tool-sparkles" aria-hidden="true"></span>
+            <span class="tool-label"><span class="emoji">📫</span> temp mail</span>
+          </article>
+        </a>
+      </div>
+    </section>
+
+    <div class="back-link reveal-on-scroll">
+      <a href="index.html">← back</a>
+    </div>
+  </main>
+
+  <script src="assets/tilt.js" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -2,89 +2,75 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>BopSec</title>
-  <style>
-    @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600&display=swap');
-
-    body {
-      margin: 0;
-      padding: 0;
-      background-color: #0b0f14; /* Perfect match with banner edge */
-      font-family: 'Playfair Display', serif;
-      color: #e6d8a8;
-      text-align: center;
-    }
-
-    .hero {
-      padding: 80px 20px 60px;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-    }
-
-    .hero .logo {
-      max-width: 600px;
-      width: 100%;
-      border-radius: 12px;
-      margin-bottom: 50px;
-      box-shadow: none;
-    }
-
-    h1 {
-      font-size: 2.4rem;
-      color: #f0e6b2;
-      margin: 0;
-    }
-
-    .subline {
-      font-size: 1rem;
-      color: #c2b280;
-      font-style: italic;
-      margin-top: 0.3rem;
-      margin-bottom: 40px;
-    }
-
-    nav {
-      display: flex;
-      justify-content: center;
-      flex-wrap: wrap;
-      gap: 60px;
-      padding: 30px 0;
-      border-top: 1px solid #2f2f2f;
-      border-bottom: 1px solid #2f2f2f;
-      max-width: 1000px;
-      margin: 0 auto;
-    }
-
-    nav a {
-      color: #fdf5c7;
-      text-decoration: none;
-      font-size: 1.25rem;
-      font-weight: bold;
-      transition: 0.3s ease;
-    }
-
-    nav a:hover {
-      color: #ffffff;
-      text-shadow: 0 0 8px #d1b66f;
-    }
-  </style>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>bopsec — home</title>
+  <link rel="stylesheet" href="assets/chillwave.css" />
 </head>
 <body>
-  <section class="hero">
-    <img class="logo" src="bopsec-banner.png" alt="BopSec Banner" />
-    <h1>yooo what is this</h1>
-    <p class="subline">do not take anything here seriously </p>
-  </section>
+  <main>
+    <nav class="nav-glass reveal-on-scroll" aria-label="Primary">
+      <a class="nav-link" href="/osint.html">osint</a>
+      <a class="nav-link" href="/ctf.html">ctf</a>
+      <a class="nav-link" href="/pentest.html">pentest</a>
+      <a class="nav-link" href="/ai.html">ai</a>
+      <a class="nav-link" href="/general.html">general</a>
+    </nav>
 
-  <nav>
-    <a href="/osint.html">osint tools</a>
-    <a href="/ctf.html">ctf tools</a>
-    <a href="/pentest.html">pentest tools</a>
-    <a href="/ai.html">ai tools</a>
-    <a href="/general.html">general</a>
-  </nav>
+    <section class="hero reveal-on-scroll">
+      <div class="floating-orb" style="top:-40px; right:80px;"></div>
+      <div class="floating-orb orb-pink orb-small" style="bottom:20px; left:60px;"></div>
+      <div class="floating-orb orb-pink" style="top:120px; left:-30px;"></div>
+      <div class="scanline" aria-hidden="true"></div>
+      <div class="hero-content">
+        <img class="logo" src="bopsec-banner.png" alt="BopSec banner" />
+        <h1 class="holo-title">bopsec</h1>
+        <p class="tagline">this is all for fun and i'm just messing around.</p>
+        <div class="cta-row">
+          <button class="cta-button" type="button">tools</button>
+          <button class="cta-button" type="button">vibes</button>
+        </div>
+      </div>
+    </section>
+
+    <div class="orbital-strip reveal-on-scroll" aria-hidden="true"></div>
+
+    <section class="tool-section reveal-on-scroll">
+      <h2 class="section-title">pick a lane</h2>
+      <div class="tool-grid">
+        <a class="tool-link" href="/osint.html">
+          <article class="tool-card">
+            <span class="tool-sparkles" aria-hidden="true"></span>
+            <span class="tool-label"><span class="emoji">🔎</span> osint</span>
+          </article>
+        </a>
+        <a class="tool-link" href="/ctf.html">
+          <article class="tool-card">
+            <span class="tool-sparkles" aria-hidden="true"></span>
+            <span class="tool-label"><span class="emoji">🕹️</span> ctf</span>
+          </article>
+        </a>
+        <a class="tool-link" href="/pentest.html">
+          <article class="tool-card">
+            <span class="tool-sparkles" aria-hidden="true"></span>
+            <span class="tool-label"><span class="emoji">💥</span> pentest</span>
+          </article>
+        </a>
+        <a class="tool-link" href="/ai.html">
+          <article class="tool-card">
+            <span class="tool-sparkles" aria-hidden="true"></span>
+            <span class="tool-label"><span class="emoji">🤖</span> ai</span>
+          </article>
+        </a>
+        <a class="tool-link" href="/general.html">
+          <article class="tool-card">
+            <span class="tool-sparkles" aria-hidden="true"></span>
+            <span class="tool-label"><span class="emoji">🧰</span> general</span>
+          </article>
+        </a>
+      </div>
+    </section>
+  </main>
+
+  <script src="assets/tilt.js" defer></script>
 </body>
 </html>

--- a/osint.html
+++ b/osint.html
@@ -2,130 +2,66 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>BopSec — OSINT Tools</title>
-  <style>
-    @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600&display=swap');
-
-    body {
-      margin: 0;
-      padding: 0;
-      background-color: #0b0f14;
-      font-family: 'Playfair Display', serif;
-      color: #e6d8a8;
-      text-align: center;
-    }
-
-    .hero {
-      padding: 60px 20px 40px;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-    }
-
-    .logo {
-      max-width: 600px;
-      width: 100%;
-      border-radius: 12px;
-      margin-bottom: 40px;
-    }
-
-    h1 {
-      font-size: 2.2rem;
-      margin-bottom: 10px;
-      color: #f0e6b2;
-    }
-
-    .subline {
-      font-size: 1rem;
-      color: #c2b280;
-      font-style: italic;
-      margin-bottom: 40px;
-    }
-
-    .tool-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-      gap: 40px;
-      max-width: 1000px;
-      margin: 0 auto 60px;
-      padding: 0 20px;
-    }
-
-    .tool {
-      border: 1px solid #2f2f2f;
-      padding: 20px;
-      border-radius: 12px;
-      background-color: #0d1218;
-      transition: transform 0.2s ease;
-    }
-
-    .tool:hover {
-      transform: scale(1.03);
-    }
-
-    .tool a {
-      color: #fdf5c7;
-      text-decoration: none;
-      font-size: 1.1rem;
-      font-weight: bold;
-    }
-
-    .tool a:hover {
-      color: #ffffff;
-      text-shadow: 0 0 8px #d1b66f;
-    }
-
-    footer {
-      margin-top: 40px;
-      padding: 30px;
-      font-size: 0.9rem;
-      color: #666;
-    }
-
-    .back {
-      margin-top: 20px;
-    }
-
-    .back a {
-      color: #aaa;
-      text-decoration: none;
-      font-size: 0.95rem;
-    }
-
-    .back a:hover {
-      color: #ddd;
-    }
-  </style>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>bopsec — osint</title>
+  <link rel="stylesheet" href="assets/chillwave.css" />
 </head>
 <body>
-  <section class="hero">
-    <img class="logo" src="bopsec-banner.png" alt="BopSec Banner" />
-    <h1>OSINT</h1>
-    <p class="subline">osint lol</p>
-  </section>
+  <main>
+    <nav class="nav-glass reveal-on-scroll" aria-label="Primary">
+      <a class="nav-link" href="/index.html">home</a>
+      <a class="nav-link" href="/ctf.html">ctf</a>
+      <a class="nav-link" href="/pentest.html">pentest</a>
+      <a class="nav-link" href="/ai.html">ai</a>
+      <a class="nav-link" href="/general.html">general</a>
+    </nav>
 
-  <section class="tool-grid">
-    <div class="tool">
-      <a href="https://picarta.ai" target="_blank">🖼 Image Location Search</a>
-    </div>
-    <div class="tool">
-      <a href="https://www.whoxy.com" target="_blank">🌐 Whois API</a>
-    </div>
-    <div class="tool">
-      <a href="https://geospy.ai" target="_blank">🛰 GeoSpy</a>
-    </div>
-    <div class="tool">
-      <a href="https://crt.sh" target="_blank">📜 Certificate Search</a>
-    </div>
-  </section>
+    <section class="hero reveal-on-scroll">
+      <div class="floating-orb" style="top:-60px; right:140px;"></div>
+      <div class="floating-orb orb-pink" style="bottom:-30px; left:60px;"></div>
+      <div class="floating-orb orb-small" style="top:160px; left:240px;"></div>
+      <div class="scanline" aria-hidden="true"></div>
+      <div class="hero-content">
+        <h1 class="holo-title">osint</h1>
+        <p class="tagline">open source snooping just for kicks.</p>
+      </div>
+    </section>
 
-  <div class="back">
-    <a href="index.html">← Return to main site</a>
-  </div>
+    <section class="tool-section reveal-on-scroll">
+      <h2 class="section-title">tools</h2>
+      <div class="tool-grid">
+        <a class="tool-link" href="https://picarta.ai" target="_blank" rel="noopener">
+          <article class="tool-card">
+            <span class="tool-sparkles" aria-hidden="true"></span>
+            <span class="tool-label"><span class="emoji">🖼</span> image location search</span>
+          </article>
+        </a>
+        <a class="tool-link" href="https://www.whoxy.com" target="_blank" rel="noopener">
+          <article class="tool-card">
+            <span class="tool-sparkles" aria-hidden="true"></span>
+            <span class="tool-label"><span class="emoji">🌐</span> whois api</span>
+          </article>
+        </a>
+        <a class="tool-link" href="https://geospy.ai" target="_blank" rel="noopener">
+          <article class="tool-card">
+            <span class="tool-sparkles" aria-hidden="true"></span>
+            <span class="tool-label"><span class="emoji">🛰</span> geospy</span>
+          </article>
+        </a>
+        <a class="tool-link" href="https://crt.sh" target="_blank" rel="noopener">
+          <article class="tool-card">
+            <span class="tool-sparkles" aria-hidden="true"></span>
+            <span class="tool-label"><span class="emoji">📜</span> certificate search</span>
+          </article>
+        </a>
+      </div>
+    </section>
 
-  <footer>
-    ?
-  </footer>
+    <div class="back-link reveal-on-scroll">
+      <a href="index.html">← back</a>
+    </div>
+  </main>
+
+  <script src="assets/tilt.js" defer></script>
 </body>
 </html>

--- a/pentest.html
+++ b/pentest.html
@@ -1,97 +1,67 @@
-<!-- pentest.html -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>BopSec — Pentest Tools</title>
-  <style>
-    body {
-      margin: 0;
-      padding: 0;
-      background-color: #0b0f14;
-      font-family: 'Playfair Display', serif;
-      color: #e6d8a8;
-      text-align: center;
-    }
-    .hero {
-      padding: 60px 20px 40px;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-    }
-    .logo {
-      max-width: 600px;
-      width: 100%;
-      border-radius: 12px;
-      margin-bottom: 40px;
-    }
-    h1 {
-      font-size: 2.2rem;
-      margin-bottom: 10px;
-      color: #f0e6b2;
-    }
-    .subline {
-      font-size: 1rem;
-      color: #c2b280;
-      font-style: italic;
-      margin-bottom: 40px;
-    }
-    .tool-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-      gap: 40px;
-      max-width: 1000px;
-      margin: 0 auto 60px;
-      padding: 0 20px;
-    }
-    .tool {
-      border: 1px solid #2f2f2f;
-      padding: 20px;
-      border-radius: 12px;
-      background-color: #0d1218;
-      transition: transform 0.2s ease;
-    }
-    .tool:hover {
-      transform: scale(1.03);
-    }
-    .tool a {
-      color: #fdf5c7;
-      text-decoration: none;
-      font-size: 1.1rem;
-      font-weight: bold;
-    }
-    .tool a:hover {
-      color: #ffffff;
-      text-shadow: 0 0 8px #d1b66f;
-    }
-    .back {
-      margin-bottom: 40px;
-    }
-    .back a {
-      color: #aaa;
-      text-decoration: none;
-      font-size: 0.95rem;
-    }
-    .back a:hover {
-      color: #ddd;
-    }
-  </style>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>bopsec — pentest</title>
+  <link rel="stylesheet" href="assets/chillwave.css" />
 </head>
 <body>
-  <section class="hero">
-    <img class="logo" src="bopsec-banner.png" alt="BopSec Banner" />
-    <h1>pentest</h1>
-    <p class="subline">just some small infosec stuff</p>
-  </section>
-  <section class="tool-grid">
-    <div class="tool"><a href="https://github.com/hackerai-tech/PentestGPT" target="_blank">🤖 PentestGPT</a></div>
-    <div class="tool"><a href="https://www.bugbountyhunting.com/" target="_blank">🕷 Bug Bounty Hunting</a></div>
-    <div class="tool"><a href="https://0dayfans.com/" target="_blank">💣 0dayfans</a></div>
-    <div class="tool"><a href="https://portswigger.net/web-security/sql-injection/cheat-sheet" target="_blank">🧪 SQLi Cheat Sheet</a></div>
-  </section>
-  <div class="back">
-    <a href="index.html">← Return to main site</a>
-  </div>
+  <main>
+    <nav class="nav-glass reveal-on-scroll" aria-label="Primary">
+      <a class="nav-link" href="/index.html">home</a>
+      <a class="nav-link" href="/osint.html">osint</a>
+      <a class="nav-link" href="/ctf.html">ctf</a>
+      <a class="nav-link" href="/ai.html">ai</a>
+      <a class="nav-link" href="/general.html">general</a>
+    </nav>
+
+    <section class="hero reveal-on-scroll">
+      <div class="floating-orb" style="top:-40px; left:80px;"></div>
+      <div class="floating-orb orb-pink" style="bottom:-20px; right:70px;"></div>
+      <div class="floating-orb orb-small" style="top:200px; right:200px;"></div>
+      <div class="scanline" aria-hidden="true"></div>
+      <div class="hero-content">
+        <h1 class="holo-title">pentest</h1>
+        <p class="tagline">offense bits i tinker with.</p>
+      </div>
+    </section>
+
+    <section class="tool-section reveal-on-scroll">
+      <h2 class="section-title">tools</h2>
+      <div class="tool-grid">
+        <a class="tool-link" href="https://github.com/hackerai-tech/PentestGPT" target="_blank" rel="noopener">
+          <article class="tool-card">
+            <span class="tool-sparkles" aria-hidden="true"></span>
+            <span class="tool-label"><span class="emoji">🤖</span> pentestgpt</span>
+          </article>
+        </a>
+        <a class="tool-link" href="https://www.bugbountyhunting.com/" target="_blank" rel="noopener">
+          <article class="tool-card">
+            <span class="tool-sparkles" aria-hidden="true"></span>
+            <span class="tool-label"><span class="emoji">🕷</span> bug bounty hunting</span>
+          </article>
+        </a>
+        <a class="tool-link" href="https://0dayfans.com/" target="_blank" rel="noopener">
+          <article class="tool-card">
+            <span class="tool-sparkles" aria-hidden="true"></span>
+            <span class="tool-label"><span class="emoji">💣</span> 0dayfans</span>
+          </article>
+        </a>
+        <a class="tool-link" href="https://portswigger.net/web-security/sql-injection/cheat-sheet" target="_blank" rel="noopener">
+          <article class="tool-card">
+            <span class="tool-sparkles" aria-hidden="true"></span>
+            <span class="tool-label"><span class="emoji">🧪</span> sqli cheat sheet</span>
+          </article>
+        </a>
+      </div>
+    </section>
+
+    <div class="back-link reveal-on-scroll">
+      <a href="index.html">← back</a>
+    </div>
+  </main>
+
+  <script src="assets/tilt.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace remaining "drift" branding on the homepage with a short, lowercase greeting and pared-down calls to action
- update navigation, headings, and taglines across ai, ctf, osint, pentest, and general pages to use minimalist lowercase copy
- rename each tool tile and back link to match the simplified tone while keeping the existing animated styling

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d94583a81483278c1770065df4f310