### PR TITLE
Add API user agent header for price refresh

### DIFF
--- a/delve.html
+++ b/delve.html
@@ -228,7 +228,15 @@ async function fetchPrices() {
 
     try {
         const ids = wikiItems.map(item => item.id).join(",");
-        const latestResponse = await fetch(`https://prices.runescape.wiki/api/v1/osrs/latest?id=${ids}`);
+        const latestResponse = await fetch(
+            `https://prices.runescape.wiki/api/v1/osrs/latest?id=${ids}`,
+            {
+                headers: {
+                    "Accept": "application/json",
+                    "Api-User-Agent": "bopsec/delveprices"
+                }
+            }
+        );
         if (!latestResponse.ok) {
             throw new Error(`Latest price request failed (${latestResponse.status})`);
         }


### PR DESCRIPTION
## Summary
- add an explicit Api-User-Agent header when requesting wiki price data so the endpoint can identify the client

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d969ecb6c083278712fcad49a1dc74