### PR TITLE
Fix multi-item OSRS price fetch in delve tool

### DIFF
--- a/delve.html
+++ b/delve.html
@@ -227,9 +227,11 @@ async function fetchPrices() {
     statusEl.textContent = "Fetching latest guide prices...";
 
     try {
-        const ids = wikiItems.map(item => item.id).join(",");
+        const latestUrl = new URL("https://prices.runescape.wiki/api/v1/osrs/latest");
+        wikiItems.forEach(item => latestUrl.searchParams.append("id", item.id));
+
         const latestResponse = await fetch(
-            `https://prices.runescape.wiki/api/v1/osrs/latest?id=${ids}`,
+            latestUrl,
             {
                 headers: {
                     "Accept": "application/json",


### PR DESCRIPTION
## Summary
- build the OSRS wiki price query using repeated `id` parameters so every item is requested
- ensure the price refresh captures all configured items rather than only the first

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d96e54ac4c83278115264d1be80f31