### PR TITLE
Fetch OSRS prices without filtering

### DIFF
--- a/delve.html
+++ b/delve.html
@@ -227,9 +227,8 @@ async function fetchPrices() {
     statusEl.textContent = "Fetching latest guide prices...";
 
     try {
-        const ids = wikiItems.map(item => item.id).join(",");
         const latestResponse = await fetch(
-            `https://prices.runescape.wiki/api/v1/osrs/latest?id=${ids}`,
+            "https://prices.runescape.wiki/api/v1/osrs/latest",
             {
                 headers: {
                     "Accept": "application/json",


### PR DESCRIPTION
## Summary
- remove the id filter when requesting the OSRS Wiki latest prices so the response includes every tracked item
- continue deriving guide prices for the configured items from the returned dataset

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d96e54ac4c83278115264d1be80f31