### PR TITLE
Remove status label and refresh hero ASCII

### DIFF
--- a/ai.html
+++ b/ai.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>bopsec — ai</title>
+  <title>bopsec</title>
   <link rel="stylesheet" href="assets/chillwave.css" />
 </head>
 <body class="mode-retro">
@@ -17,61 +17,61 @@
         <a class="nav-link" href="/ai.html" aria-current="page">ai</a>
         <a class="nav-link" href="/general.html">general</a>
       </div>
-      <button class="mode-toggle" type="button" data-mode-toggle>Engage suspiciously minimal mode</button>
+      <button class="mode-toggle" type="button" data-mode-toggle>minimal</button>
     </nav>
 
     <section class="hero">
       <div class="crt-panel">
         <pre class="ascii-banner" aria-hidden="true">
-     ___      __
-    /   | __ / /___ ___
-   / /| |/ // / __ `__ \
-  / ___ / // / / / / / /
- /_/  |_|\___/_/ /_/ /_/
+    ██      ██████████
+  ██  ██        ██
+██████████      ██
+██      ██      ██
+██      ██  ██████████
         </pre>
-        <h1 class="page-title">ai suggestion booth</h1>
-        <p class="deadpan">outputs remain pleasantly beige unless provoked.</p>
-        <p class="tagline">Conjure synthetic sentences with the weary grace of an overcaffeinated librarian. Paperclips included.</p>
+        <h1 class="page-title">ai</h1>
+        <p class="deadpan">calm prompts.</p>
+        <p class="tagline">soft replies.</p>
         <div class="ticker" role="text">
-          <div class="ticker__inner">model warmed ▒▒ alignment memos ▒▒ dataset ethically dusted ▒▒ disclaimers on standby</div>
+          <div class="ticker__inner">models ▒▒ prompts ▒▒ replies ▒▒ quiet</div>
         </div>
       </div>
     </section>
 
     <section class="tool-section">
-      <h2 class="section-title">algorithmic amenities</h2>
-      <p class="section-note">Please buff fingerprints off the neural interface before leaving.</p>
+      <h2 class="section-title">tools</h2>
+      <p class="section-note">uhhhh</p>
       <div class="tool-grid">
         <a class="tool-link" href="https://chat.deepseek.com/" target="_blank" rel="noopener">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🧠</span> deepseek // contemplative compute</span>
+            <span class="tool-label"><span class="emoji">🧠</span> deepseek</span>
           </article>
         </a>
         <a class="tool-link" href="https://claude.ai/new" target="_blank" rel="noopener">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🤖</span> claude // polite drafts</span>
+            <span class="tool-label"><span class="emoji">🤖</span> claude</span>
           </article>
         </a>
         <a class="tool-link" href="https://www.readtheirlips.com/" target="_blank" rel="noopener">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">👄</span> lipreader // hush-hush transcription</span>
+            <span class="tool-label"><span class="emoji">👄</span> lipreader</span>
           </article>
         </a>
         <a class="tool-link" href="https://app.suno.ai/" target="_blank" rel="noopener">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🎶</span> suno.ai // muzak for meetings</span>
+            <span class="tool-label"><span class="emoji">🎶</span> suno</span>
           </article>
         </a>
         <a class="tool-link" href="https://gamma.app/create" target="_blank" rel="noopener">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">📊</span> gamma.app // slide decks on decaf</span>
+            <span class="tool-label"><span class="emoji">📊</span> gamma</span>
           </article>
         </a>
       </div>
     </section>
 
     <div class="back-link">
-      <a href="index.html">← return to the unnervingly calm lobby</a>
+      <a href="index.html">← back</a>
     </div>
   </main>
 

--- a/assets/chillwave.css
+++ b/assets/chillwave.css
@@ -216,16 +216,6 @@ body.mode-modern .deadpan {
   color: var(--text-soft);
 }
 
-body.mode-modern .deadpan::before {
-  content: 'note:';
-  color: var(--text-soft);
-  opacity: 1;
-  margin-right: 6px;
-  text-transform: uppercase;
-  letter-spacing: 0.2em;
-  font-size: 0.7rem;
-}
-
 body.mode-modern .tagline {
   font-family: var(--font-body);
   font-size: 0.95rem;
@@ -279,17 +269,25 @@ body.mode-modern .section-title {
 }
 
 body.mode-modern .tool-grid {
-  display: block;
+  display: grid;
+  gap: 14px;
 }
 
 body.mode-modern .tool-link {
   display: block;
-  padding: 12px 0;
-  border-bottom: 1px solid #e2e2e2;
+  padding: 14px 18px;
+  border: 1px solid #e2e2e2;
+  border-radius: 10px;
+  background: linear-gradient(180deg, #ffffff, #f7f7f5);
+  text-decoration: none;
+  color: inherit;
+  transition: background 0.2s ease, border-color 0.2s ease;
 }
 
-body.mode-modern .tool-link:last-child {
-  border-bottom: none;
+body.mode-modern .tool-link:hover,
+body.mode-modern .tool-link:focus-visible {
+  background: #f0f0ee;
+  border-color: #d0d0ce;
 }
 
 body.mode-modern .tool-card {
@@ -548,12 +546,6 @@ body.mode-retro .section-note {
   letter-spacing: 0.22em;
   text-transform: uppercase;
   box-shadow: 0 0 18px rgba(0, 255, 255, 0.35);
-}
-
-.deadpan::before {
-  content: 'status:';
-  color: var(--text-soft);
-  opacity: 0.8;
 }
 
 .section-note {

--- a/assets/theme-toggle.js
+++ b/assets/theme-toggle.js
@@ -17,7 +17,7 @@
 
   const updateButton = () => {
     const isModern = body.classList.contains('mode-modern');
-    toggle.textContent = isModern ? 'Return to ostentatiously boring mode' : 'Engage suspiciously minimal mode';
+    toggle.textContent = isModern ? 'retro' : 'minimal';
     toggle.setAttribute('aria-pressed', String(isModern));
   };
 

--- a/ctf.html
+++ b/ctf.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>bopsec — ctf</title>
+  <title>bopsec</title>
   <link rel="stylesheet" href="assets/chillwave.css" />
 </head>
 <body class="mode-retro">
@@ -17,56 +17,56 @@
         <a class="nav-link" href="/ai.html">ai</a>
         <a class="nav-link" href="/general.html">general</a>
       </div>
-      <button class="mode-toggle" type="button" data-mode-toggle>Engage suspiciously minimal mode</button>
+      <button class="mode-toggle" type="button" data-mode-toggle>minimal</button>
     </nav>
 
     <section class="hero">
       <div class="crt-panel">
         <pre class="ascii-banner" aria-hidden="true">
-   ________ _______   ______
-  / ____/ // / ___/  / ____/
- / /   / // /\__ \ / / __  
-/ /___/__  /___/ // /_/ /   
-\____/ /_/\____(_)\____/    
+  ████████  ██████████  ██████████
+██              ██      ██
+██              ██      ████████
+██              ██      ██
+  ████████      ██      ██
         </pre>
-        <h1 class="page-title">ctf compliance arena</h1>
-        <p class="deadpan">flags are strictly hypothetical. please cheer internally.</p>
-        <p class="tagline">Disassemble puzzles with the quiet efficiency of a spreadsheet tutorial while lasers pretend not to flash.</p>
+        <h1 class="page-title">ctf</h1>
+        <p class="deadpan">quiet flags.</p>
+        <p class="tagline">calm hacks.</p>
         <div class="ticker" role="text">
-          <div class="ticker__inner">buffers padded ▒▒ scoreboard sanitized ▒▒ patch tuesday forever ▒▒ nothing is on fire</div>
+          <div class="ticker__inner">buffers ▒▒ scores ▒▒ loops ▒▒ chill</div>
         </div>
       </div>
     </section>
 
     <section class="tool-section">
-      <h2 class="section-title">approved exploit exercises</h2>
-      <p class="section-note">Celebrate captures with a reserved nod and perhaps a pastel donut.</p>
+      <h2 class="section-title">tools</h2>
+      <p class="section-note">uhhhh</p>
       <div class="tool-grid">
         <a class="tool-link" href="https://grep.app/" target="_blank" rel="noopener">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🔍</span> grep.app // codeword scavenger</span>
+            <span class="tool-label"><span class="emoji">🔍</span> grep</span>
           </article>
         </a>
         <a class="tool-link" href="https://lostsec.xyz/" target="_blank" rel="noopener">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🕵️‍♂️</span> lostsec.xyz // clandestine-ish</span>
+            <span class="tool-label"><span class="emoji">🕵️‍♂️</span> lostsec</span>
           </article>
         </a>
         <a class="tool-link" href="https://github.com/SandySekharan/CTF-tool" target="_blank" rel="noopener">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🧰</span> sandy's ctf toolkit // meticulously tidy</span>
+            <span class="tool-label"><span class="emoji">🧰</span> toolkit</span>
           </article>
         </a>
         <a class="tool-link" href="https://github.com/0xor0ne/awesome-list/tree/main" target="_blank" rel="noopener">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">📚</span> awesome list (0xor0ne) // light reading</span>
+            <span class="tool-label"><span class="emoji">📚</span> list</span>
           </article>
         </a>
       </div>
     </section>
 
     <div class="back-link">
-      <a href="index.html">← quietly exit to the lobby</a>
+      <a href="index.html">← back</a>
     </div>
   </main>
 

--- a/general.html
+++ b/general.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>bopsec — general</title>
+  <title>bopsec</title>
   <link rel="stylesheet" href="assets/chillwave.css" />
 </head>
 <body class="mode-retro">
@@ -17,52 +17,51 @@
         <a class="nav-link" href="/ai.html">ai</a>
         <a class="nav-link" href="/general.html" aria-current="page">general</a>
       </div>
-      <button class="mode-toggle" type="button" data-mode-toggle>Engage suspiciously minimal mode</button>
+      <button class="mode-toggle" type="button" data-mode-toggle>minimal</button>
     </nav>
 
     <section class="hero">
       <div class="crt-panel">
         <pre class="ascii-banner" aria-hidden="true">
-   ______             __                __
-  / ____/___  ____ _/ /_____ _____    / /
- / / __/ __ \ / __ `/ __/ __ `/ __ \  / / 
-/ /_/ / /_/ / /_/ / /_/ /_/ / /_/ / /_/  
-\____/\____/\__,_/\__/\__,_/ .___/ (_)   
-                             /_/           
+  ████████  ██████████  ██      ██  ██████████  ████████        ██      ██
+██          ██          ████    ██  ██          ██      ██    ██  ██    ██
+██    ████  ████████    ██  ██  ██  ████████    ████████    ██████████  ██
+██      ██  ██          ██    ████  ██          ██    ██    ██      ██  ██
+  ████████  ██████████  ██      ██  ██████████  ██      ██  ██      ██  ██████████
         </pre>
-        <h1 class="page-title">general comfort locker</h1>
-        <p class="deadpan">everything here is aggressively average. please do not gasp.</p>
-        <p class="tagline">Collect utilities and diversions the way you reorganize a filing cabinet: methodically, with a smirk.</p>
+        <h1 class="page-title">general</h1>
+        <p class="deadpan">steady stash.</p>
+        <p class="tagline">calm picks.</p>
         <div class="ticker" role="text">
-          <div class="ticker__inner">stretch reminder ▒▒ hydration log ▒▒ firmware feelings ▒▒ glamour levels nominal</div>
+          <div class="ticker__inner">stretch ▒▒ hydrate ▒▒ firmware ▒▒ mellow</div>
         </div>
       </div>
     </section>
 
     <section class="tool-section">
-      <h2 class="section-title">mildly helpful miscellany</h2>
-      <p class="section-note">Use responsibly and report any unexpected sparkles to facilities.</p>
+      <h2 class="section-title">tools</h2>
+      <p class="section-note">uhhhh</p>
       <div class="tool-grid">
         <a class="tool-link" href="https://trakt.tv/dashboard" target="_blank" rel="noopener">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🎬</span> trakt dashboard // curated calm</span>
+            <span class="tool-label"><span class="emoji">🎬</span> trakt</span>
           </article>
         </a>
         <a class="tool-link" href="https://fmhy.net/" target="_blank" rel="noopener">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🌐</span> fmhy (free media) // library annex</span>
+            <span class="tool-label"><span class="emoji">🌐</span> fmhy</span>
           </article>
         </a>
         <a class="tool-link" href="https://temp-mail.org/" target="_blank" rel="noopener">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">📫</span> temp mail // polite burner inbox</span>
+            <span class="tool-label"><span class="emoji">📫</span> temp mail</span>
           </article>
         </a>
       </div>
     </section>
 
     <div class="back-link">
-      <a href="index.html">← meander back to the lobby</a>
+      <a href="index.html">← back</a>
     </div>
   </main>
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>bopsec — home</title>
+  <title>bopsec</title>
   <link rel="stylesheet" href="assets/chillwave.css" />
 </head>
 <body class="mode-retro">
@@ -16,59 +16,58 @@
         <a class="nav-link" href="/ai.html">ai</a>
         <a class="nav-link" href="/general.html">general</a>
       </div>
-      <button class="mode-toggle" type="button" data-mode-toggle>Engage suspiciously minimal mode</button>
+      <button class="mode-toggle" type="button" data-mode-toggle>minimal</button>
     </nav>
 
     <section class="hero">
       <div class="crt-panel">
         <pre class="ascii-banner" aria-hidden="true">
-  ____              ____   ____   ______            __
- / __ )____  ____ _/ __ \ / __ ) / ____/___  ____  / /
-/ __  / __ \/ __ `/ / / // __  |/ /   / __ \/ __ \/ / 
-/ /_/ / /_/ / /_/ / /_/ // /_/ / /___/ /_/ / /_/ / /  
-/_____/ .___/\__,_/_____/_____/\____/\____/\____/_/   
-     /_/                                               
+████████      ██████    ████████      ████████  ██████████    ████████
+██      ██  ██      ██  ██      ██  ██          ██          ██
+████████    ██      ██  ████████      ██████    ████████    ██
+██      ██  ██      ██  ██                  ██  ██          ██
+████████      ██████    ██          ████████    ██████████    ████████
         </pre>
-        <h1 class="page-title">bopsec compliance intranet</h1>
-        <p class="deadpan">absolutely routine operations. please maintain a neutral facial expression.</p>
-        <p class="tagline">Standard issue resources arranged inside an entirely ordinary shimmering vortex. Kindly ignore the glitter.</p>
+        <h1 class="page-title">bopsec</h1>
+        <p class="deadpan">mundane portal.</p>
+        <p class="tagline">static glow.</p>
         <div class="ticker" role="text">
-          <div class="ticker__inner">monotony confirmed ▒▒ please disregard the plasma arcs ▒▒ forms filed ▒▒ cubicles calibrated ▒▒ everything is normal</div>
+          <div class="ticker__inner">normalcy ▒▒ paperwork ▒▒ compliance ▒▒ beige</div>
         </div>
         <div class="cta-row">
-          <a class="retro-button" href="#tools">acknowledge compliance</a>
-          <a class="retro-button alt" href="mailto:hello@bopsec.space">log an innocuous email</a>
+          <a class="retro-button" href="#tools">enter</a>
+          <a class="retro-button alt" href="mailto:bop@bopsec.com">email</a>
         </div>
       </div>
     </section>
 
     <section class="tool-section" id="tools">
-      <h2 class="section-title">mandatory navigation indexes</h2>
-      <p class="section-note">Select any workstation. They are all identically beige despite the catastrophic glow.</p>
+      <h2 class="section-title">navigation</h2>
+      <p class="section-note">uhhhh</p>
       <div class="tool-grid">
         <a class="tool-link" href="/osint.html">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🔎</span> osint desk // extremely normal</span>
+            <span class="tool-label"><span class="emoji">🔎</span> osint</span>
           </article>
         </a>
         <a class="tool-link" href="/ctf.html">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🕹️</span> ctf arena // nothing flashy</span>
+            <span class="tool-label"><span class="emoji">🕹️</span> ctf</span>
           </article>
         </a>
         <a class="tool-link" href="/pentest.html">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">💥</span> pentest lab // just paperwork</span>
+            <span class="tool-label"><span class="emoji">💥</span> pentest</span>
           </article>
         </a>
         <a class="tool-link" href="/ai.html">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🤖</span> ai wing // strictly mundane</span>
+            <span class="tool-label"><span class="emoji">🤖</span> ai</span>
           </article>
         </a>
         <a class="tool-link" href="/general.html">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🧰</span> general cache // very plain</span>
+            <span class="tool-label"><span class="emoji">🧰</span> general</span>
           </article>
         </a>
       </div>

--- a/osint.html
+++ b/osint.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>bopsec — osint</title>
+  <title>bopsec</title>
   <link rel="stylesheet" href="assets/chillwave.css" />
 </head>
 <body class="mode-retro">
@@ -17,56 +17,56 @@
         <a class="nav-link" href="/ai.html">ai</a>
         <a class="nav-link" href="/general.html">general</a>
       </div>
-      <button class="mode-toggle" type="button" data-mode-toggle>Engage suspiciously minimal mode</button>
+      <button class="mode-toggle" type="button" data-mode-toggle>minimal</button>
     </nav>
 
     <section class="hero">
       <div class="crt-panel">
         <pre class="ascii-banner" aria-hidden="true">
-   ___  _____ _   _ _______     __
-  / _ \/ ___/| | / / ____/ |   / /
- / , _/ /__  | |/ / __/  | |  / / 
-/ /_/ /\__ \  |___/ /___  | |_/ /  
-\____/____/      /_____/  |___(_)  
+  ██████      ████████  ██████████  ██      ██  ██████████
+██      ██  ██              ██      ████    ██      ██
+██      ██    ██████        ██      ██  ██  ██      ██
+██      ██          ██      ██      ██    ████      ██
+  ██████    ████████    ██████████  ██      ██      ██
         </pre>
-        <h1 class="page-title">osint observation cubicle</h1>
-        <p class="deadpan">routine open-source reconnaissance. fluorescent lights humming at acceptable levels.</p>
-        <p class="tagline">Collect public breadcrumbs with the subdued enthusiasm of an annual report. Clipboards are optional, composure is mandatory.</p>
+        <h1 class="page-title">osint</h1>
+        <p class="deadpan">quiet scans.</p>
+        <p class="tagline">public crumbs.</p>
         <div class="ticker" role="text">
-          <div class="ticker__inner">comfortably bland updates ▒▒ cross-reference ▒▒ annotate politely ▒▒ hydrate ▒▒ maintain plausible yawns</div>
+          <div class="ticker__inner">logs ▒▒ maps ▒▒ traces ▒▒ hush</div>
         </div>
       </div>
     </section>
 
     <section class="tool-section">
-      <h2 class="section-title">catalogued instrumentation</h2>
-      <p class="section-note">Document findings with grayscale pens only. The neon flicker is coincidental.</p>
+      <h2 class="section-title">tools</h2>
+      <p class="section-note">uhhhh</p>
       <div class="tool-grid">
         <a class="tool-link" href="https://picarta.ai" target="_blank" rel="noopener">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🖼</span> image location search // politely thorough</span>
+            <span class="tool-label"><span class="emoji">🖼</span> images</span>
           </article>
         </a>
         <a class="tool-link" href="https://www.whoxy.com" target="_blank" rel="noopener">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🌐</span> whois api // entirely above board</span>
+            <span class="tool-label"><span class="emoji">🌐</span> whois</span>
           </article>
         </a>
         <a class="tool-link" href="https://geospy.ai" target="_blank" rel="noopener">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🛰</span> geospy // maps and mild intrigue</span>
+            <span class="tool-label"><span class="emoji">🛰</span> geospy</span>
           </article>
         </a>
         <a class="tool-link" href="https://crt.sh" target="_blank" rel="noopener">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">📜</span> certificate search // politely indexed</span>
+            <span class="tool-label"><span class="emoji">📜</span> certs</span>
           </article>
         </a>
       </div>
     </section>
 
     <div class="back-link">
-      <a href="index.html">← retreat to the extremely standard lobby</a>
+      <a href="index.html">← back</a>
     </div>
   </main>
 

--- a/pentest.html
+++ b/pentest.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>bopsec — pentest</title>
+  <title>bopsec</title>
   <link rel="stylesheet" href="assets/chillwave.css" />
 </head>
 <body class="mode-retro">
@@ -17,57 +17,56 @@
         <a class="nav-link" href="/ai.html">ai</a>
         <a class="nav-link" href="/general.html">general</a>
       </div>
-      <button class="mode-toggle" type="button" data-mode-toggle>Engage suspiciously minimal mode</button>
+      <button class="mode-toggle" type="button" data-mode-toggle>minimal</button>
     </nav>
 
     <section class="hero">
       <div class="crt-panel">
         <pre class="ascii-banner" aria-hidden="true">
-  ____            __             __
- / __ \____  ____/ /_____  _____/ /_
-/ / / / __ \/ __  / __/ / / / _  __/
-/ /_/ / /_/ / /_/ / /_/ /_/ /  / /_  
-\____/ .___/\__,_/\__/\__,_/   \__/  
-     /_/                                  
+████████    ██████████  ██      ██  ██████████  ██████████    ████████  ██████████
+██      ██  ██          ████    ██      ██      ██          ██              ██
+████████    ████████    ██  ██  ██      ██      ████████      ██████        ██
+██          ██          ██    ████      ██      ██                  ██      ██
+██          ██████████  ██      ██      ██      ██████████  ████████        ██
         </pre>
-        <h1 class="page-title">pentest courtesy bunker</h1>
-        <p class="deadpan">all breaches simulated. please log every triumph in triplicate.</p>
-        <p class="tagline">Prod the perimeter with the gentle patience of watering office plants. Nothing to see here, except the sparks.</p>
+        <h1 class="page-title">pentest</h1>
+        <p class="deadpan">calm probes.</p>
+        <p class="tagline">soft breach.</p>
         <div class="ticker" role="text">
-          <div class="ticker__inner">scope confirmed ▒▒ tcp handshake handshake ▒▒ clipboard sanitized ▒▒ confetti strictly prohibited</div>
+          <div class="ticker__inner">scope ▒▒ packets ▒▒ audits ▒▒ hush</div>
         </div>
       </div>
     </section>
 
     <section class="tool-section">
-      <h2 class="section-title">sanctioned intrusion rituals</h2>
-      <p class="section-note">Return every cable to its original pose when finished. Management notices everything.</p>
+      <h2 class="section-title">tools</h2>
+      <p class="section-note">uhhhh</p>
       <div class="tool-grid">
         <a class="tool-link" href="https://github.com/hackerai-tech/PentestGPT" target="_blank" rel="noopener">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🤖</span> pentestgpt // courteous automation</span>
+            <span class="tool-label"><span class="emoji">🤖</span> pentestgpt</span>
           </article>
         </a>
         <a class="tool-link" href="https://www.bugbountyhunting.com/" target="_blank" rel="noopener">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🕷</span> bug bounty hunting // friendly mischief</span>
+            <span class="tool-label"><span class="emoji">🕷</span> bug bounty</span>
           </article>
         </a>
         <a class="tool-link" href="https://0dayfans.com/" target="_blank" rel="noopener">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">💣</span> 0dayfans // perfectly contained boom</span>
+            <span class="tool-label"><span class="emoji">💣</span> 0dayfans</span>
           </article>
         </a>
         <a class="tool-link" href="https://portswigger.net/web-security/sql-injection/cheat-sheet" target="_blank" rel="noopener">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🧪</span> sqli cheat sheet // lab-approved drips</span>
+            <span class="tool-label"><span class="emoji">🧪</span> sqli sheet</span>
           </article>
         </a>
       </div>
     </section>
 
     <div class="back-link">
-      <a href="index.html">← file out to the lobby</a>
+      <a href="index.html">← back</a>
     </div>
   </main>
 


### PR DESCRIPTION
## Summary
- remove the "status"/"note" prefixes from hero callouts in both retro and minimal modes
- redraw each page's hero banner with simplified block ASCII that matches the new terse naming

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e3a58851ac8327937f3918010d6a84