### PR TITLE
Point site to GitHub writeups

### DIFF
--- a/ai.html
+++ b/ai.html
@@ -6,65 +6,34 @@
   <title>bopsec</title>
   <link rel="stylesheet" href="assets/chillwave.css" />
 </head>
-<body class="mode-retro">
+<body class="mode-minimal">
   <main class="page-shell">
     <nav class="site-nav" aria-label="Primary">
       <div class="nav-links">
         <a class="nav-link" href="/index.html">home</a>
-        <a class="nav-link" href="/osint.html">osint</a>
-        <a class="nav-link" href="/ctf.html">ctf</a>
-        <a class="nav-link" href="/pentest.html">pentest</a>
-        <a class="nav-link" href="/ai.html" aria-current="page">ai</a>
-        <a class="nav-link" href="/general.html">general</a>
+        <a class="nav-link" href="https://github.com/bopsec/ctf-writeups" target="_blank" rel="noopener">writeups repo</a>
       </div>
-      <button class="mode-toggle" type="button" data-mode-toggle>light</button>
     </nav>
 
     <section class="hero">
       <div class="crt-panel">
         <h1 class="page-title">ai</h1>
-        <p class="deadpan">calm prompts.</p>
-        <p class="tagline">Experiments, prompt logs, and notes without the blinking lights.</p>
+        <p class="deadpan">experiments log there too.</p>
+        <p class="tagline">AI-related notes and helpers travel with the rest of the writeups on GitHub.</p>
       </div>
     </section>
 
     <section class="tool-section">
-      <h2 class="section-title">tools</h2>
-      <p class="section-note">uhhhh</p>
+      <h2 class="section-title">view</h2>
+      <p class="section-note">The repository is the single source of truth.</p>
       <div class="tool-grid">
-        <a class="tool-link" href="https://chat.deepseek.com/" target="_blank" rel="noopener">
+        <a class="tool-link" href="https://github.com/bopsec/ctf-writeups" target="_blank" rel="noopener">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🧠</span> deepseek</span>
-          </article>
-        </a>
-        <a class="tool-link" href="https://claude.ai/new" target="_blank" rel="noopener">
-          <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🤖</span> claude</span>
-          </article>
-        </a>
-        <a class="tool-link" href="https://www.readtheirlips.com/" target="_blank" rel="noopener">
-          <article class="tool-card">
-            <span class="tool-label"><span class="emoji">👄</span> lipreader</span>
-          </article>
-        </a>
-        <a class="tool-link" href="https://app.suno.ai/" target="_blank" rel="noopener">
-          <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🎶</span> suno</span>
-          </article>
-        </a>
-        <a class="tool-link" href="https://gamma.app/create" target="_blank" rel="noopener">
-          <article class="tool-card">
-            <span class="tool-label"><span class="emoji">📊</span> gamma</span>
+            <span class="tool-label"><span class="emoji">🤖</span> open ai notes</span>
           </article>
         </a>
       </div>
     </section>
-
-    <div class="back-link">
-      <a href="index.html">← back</a>
-    </div>
   </main>
-
-  <script src="assets/theme-toggle.js" defer></script>
 </body>
 </html>

--- a/assets/chillwave.css
+++ b/assets/chillwave.css
@@ -1,7 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
 :root {
-  color-scheme: light dark;
+  color-scheme: dark;
 }
 
 * {
@@ -22,52 +22,28 @@ body::after {
   display: none;
 }
 
-body.mode-retro {
-  --text-main: #e8edf5;
-  --text-soft: #9ca5b5;
-  --link: #b9d8ff;
-  --link-hover: #e0ecff;
+body.mode-minimal {
+  --text-main: #e4e9f2;
+  --text-soft: #97a3b5;
+  --link: #a6d5ff;
+  --link-hover: #d1e7ff;
   --accent: #7dd3fc;
   --accent-strong: #38bdf8;
   --panel-bg: #0f1724;
-  --panel-border: #1f2a3c;
-  --panel-border-secondary: #263349;
-  --panel-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
-  --page-background: radial-gradient(circle at 20% 20%, #0f172a, #0b1220 40%, #0b0f18 75%);
-  --card-bg: #111a28;
-  --card-border: #1f2a3c;
-  --card-shadow: 0 10px 22px rgba(0, 0, 0, 0.35);
-  --button-bg: #1f2a3c;
-  --button-text: #e8edf5;
-  --button-border: #2b3950;
+  --panel-border: #182335;
+  --panel-border-secondary: #223349;
+  --panel-shadow: 0 10px 26px rgba(0, 0, 0, 0.3);
+  --page-background: #0a0f1a;
+  --card-bg: #0f1826;
+  --card-border: #1b283b;
+  --card-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+  --button-bg: #182335;
+  --button-text: #e4e9f2;
+  --button-border: #223349;
   --button-shadow: none;
-  --nav-bg: rgba(12, 17, 26, 0.8);
-  --nav-border: #1b2535;
-  --nav-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
-}
-
-body.mode-modern {
-  --text-main: #0e141b;
-  --text-soft: #5b6674;
-  --link: #0f172a;
-  --link-hover: #0f172a;
-  --accent: #0ea5e9;
-  --accent-strong: #0284c7;
-  --panel-bg: #f6f7fb;
-  --panel-border: #e1e6ef;
-  --panel-border-secondary: #c9d4e5;
-  --panel-shadow: none;
-  --page-background: #f8fafc;
-  --card-bg: #ffffff;
-  --card-border: #e5e9f0;
-  --card-shadow: 0 12px 28px rgba(15, 23, 42, 0.06);
-  --button-bg: #0f172a;
-  --button-text: #f8fafc;
-  --button-border: #0f172a;
-  --button-shadow: none;
-  --nav-bg: #f8fafc;
-  --nav-border: #e5e9f0;
-  --nav-shadow: 0 6px 18px rgba(15, 23, 42, 0.06);
+  --nav-bg: rgba(10, 15, 26, 0.85);
+  --nav-border: #1b273a;
+  --nav-shadow: 0 8px 22px rgba(0, 0, 0, 0.28);
 }
 
 .page-shell {
@@ -115,26 +91,6 @@ body.mode-modern {
   background: rgba(255, 255, 255, 0.04);
   border-color: var(--nav-border);
   color: var(--link-hover);
-}
-
-.mode-toggle {
-  margin-left: auto;
-  font-weight: 600;
-  font-size: 0.85rem;
-  letter-spacing: 0.01em;
-  background: var(--button-bg);
-  color: var(--button-text);
-  border: 1px solid var(--button-border);
-  border-radius: 12px;
-  padding: 8px 14px;
-  cursor: pointer;
-  box-shadow: var(--button-shadow);
-  transition: transform 0.2s ease, opacity 0.2s ease;
-}
-
-.mode-toggle:hover,
-.mode-toggle:focus-visible {
-  transform: translateY(-1px);
 }
 
 .hero {
@@ -307,9 +263,5 @@ footer {
     flex-direction: column;
     align-items: flex-start;
     position: static;
-  }
-
-  .mode-toggle {
-    align-self: flex-end;
   }
 }

--- a/ctf.html
+++ b/ctf.html
@@ -6,60 +6,34 @@
   <title>bopsec</title>
   <link rel="stylesheet" href="assets/chillwave.css" />
 </head>
-<body class="mode-retro">
+<body class="mode-minimal">
   <main class="page-shell">
     <nav class="site-nav" aria-label="Primary">
       <div class="nav-links">
         <a class="nav-link" href="/index.html">home</a>
-        <a class="nav-link" href="/osint.html">osint</a>
-        <a class="nav-link" href="/ctf.html" aria-current="page">ctf</a>
-        <a class="nav-link" href="/pentest.html">pentest</a>
-        <a class="nav-link" href="/ai.html">ai</a>
-        <a class="nav-link" href="/general.html">general</a>
+        <a class="nav-link" href="https://github.com/bopsec/ctf-writeups" target="_blank" rel="noopener" aria-current="page">writeups repo</a>
       </div>
-      <button class="mode-toggle" type="button" data-mode-toggle>light</button>
     </nav>
 
     <section class="hero">
       <div class="crt-panel">
         <h1 class="page-title">ctf</h1>
-        <p class="deadpan">quiet flags.</p>
-        <p class="tagline">Walkthroughs, notes, and commands that made the scoreboard move without the neon carnival.</p>
+        <p class="deadpan">all roads lead to github.</p>
+        <p class="tagline">Every competition note, command log, and flag writeup is organized in the repository.</p>
       </div>
     </section>
 
     <section class="tool-section">
-      <h2 class="section-title">tools</h2>
-      <p class="section-note">Used often; leaving them here for easy grabs.</p>
+      <h2 class="section-title">jump in</h2>
+      <p class="section-note">Browse, clone, or star the centralized writeups.</p>
       <div class="tool-grid">
-        <a class="tool-link" href="https://grep.app/" target="_blank" rel="noopener">
+        <a class="tool-link" href="https://github.com/bopsec/ctf-writeups" target="_blank" rel="noopener">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🔍</span> grep</span>
-          </article>
-        </a>
-        <a class="tool-link" href="https://lostsec.xyz/" target="_blank" rel="noopener">
-          <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🕵️‍♂️</span> lostsec</span>
-          </article>
-        </a>
-        <a class="tool-link" href="https://github.com/SandySekharan/CTF-tool" target="_blank" rel="noopener">
-          <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🧰</span> toolkit</span>
-          </article>
-        </a>
-        <a class="tool-link" href="https://github.com/0xor0ne/awesome-list/tree/main" target="_blank" rel="noopener">
-          <article class="tool-card">
-            <span class="tool-label"><span class="emoji">📚</span> list</span>
+            <span class="tool-label"><span class="emoji">🕹️</span> open ctf writeups</span>
           </article>
         </a>
       </div>
     </section>
-
-    <div class="back-link">
-      <a href="index.html">← back</a>
-    </div>
   </main>
-
-  <script src="assets/theme-toggle.js" defer></script>
 </body>
 </html>

--- a/general.html
+++ b/general.html
@@ -6,55 +6,34 @@
   <title>bopsec</title>
   <link rel="stylesheet" href="assets/chillwave.css" />
 </head>
-<body class="mode-retro">
+<body class="mode-minimal">
   <main class="page-shell">
     <nav class="site-nav" aria-label="Primary">
       <div class="nav-links">
         <a class="nav-link" href="/index.html">home</a>
-        <a class="nav-link" href="/osint.html">osint</a>
-        <a class="nav-link" href="/ctf.html">ctf</a>
-        <a class="nav-link" href="/pentest.html">pentest</a>
-        <a class="nav-link" href="/ai.html">ai</a>
-        <a class="nav-link" href="/general.html" aria-current="page">general</a>
+        <a class="nav-link" href="https://github.com/bopsec/ctf-writeups" target="_blank" rel="noopener">writeups repo</a>
       </div>
-      <button class="mode-toggle" type="button" data-mode-toggle>light</button>
     </nav>
 
     <section class="hero">
       <div class="crt-panel">
         <h1 class="page-title">general</h1>
-        <p class="deadpan">steady stash.</p>
-        <p class="tagline">Misc notes and references, trimmed down to the essentials.</p>
+        <p class="deadpan">one repo for everything.</p>
+        <p class="tagline">Catch-all notes, cheats, and references sit alongside the CTF writeups in GitHub.</p>
       </div>
     </section>
 
     <section class="tool-section">
-      <h2 class="section-title">tools</h2>
-      <p class="section-note">uhhhh</p>
+      <h2 class="section-title">dig in</h2>
+      <p class="section-note">Open the repository to view the latest general notes.</p>
       <div class="tool-grid">
-        <a class="tool-link" href="https://trakt.tv/dashboard" target="_blank" rel="noopener">
+        <a class="tool-link" href="https://github.com/bopsec/ctf-writeups" target="_blank" rel="noopener">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🎬</span> trakt</span>
-          </article>
-        </a>
-        <a class="tool-link" href="https://fmhy.net/" target="_blank" rel="noopener">
-          <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🌐</span> fmhy</span>
-          </article>
-        </a>
-        <a class="tool-link" href="https://temp-mail.org/" target="_blank" rel="noopener">
-          <article class="tool-card">
-            <span class="tool-label"><span class="emoji">📫</span> temp mail</span>
+            <span class="tool-label"><span class="emoji">🧰</span> open general notes</span>
           </article>
         </a>
       </div>
     </section>
-
-    <div class="back-link">
-      <a href="index.html">← back</a>
-    </div>
   </main>
-
-  <script src="assets/theme-toggle.js" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -6,60 +6,34 @@
   <title>bopsec</title>
   <link rel="stylesheet" href="assets/chillwave.css" />
 </head>
-<body class="mode-retro">
+<body class="mode-minimal">
   <main class="page-shell">
     <nav class="site-nav" aria-label="Primary">
       <div class="nav-links">
-        <a class="nav-link" href="/osint.html">osint</a>
-        <a class="nav-link" href="/ctf.html">ctf</a>
-        <a class="nav-link" href="/pentest.html">pentest</a>
-        <a class="nav-link" href="/ai.html">ai</a>
-        <a class="nav-link" href="/general.html">general</a>
+        <a class="nav-link" href="/index.html" aria-current="page">home</a>
+        <a class="nav-link" href="https://github.com/bopsec/ctf-writeups" target="_blank" rel="noopener">writeups repo</a>
       </div>
-      <button class="mode-toggle" type="button" data-mode-toggle>light</button>
     </nav>
 
     <section class="hero">
       <div class="crt-panel">
         <h1 class="page-title">bopsec</h1>
-        <p class="deadpan">quiet writeups, softer palette.</p>
-        <p class="tagline">Capture notes from CTFs, OSINT, pentests, and stray curiosities without the retina burn.</p>
+        <p class="deadpan">writeups, now centralized.</p>
+        <p class="tagline">All CTF notes and walkthroughs now live on GitHub for easier browsing and cloning.</p>
       </div>
     </section>
 
     <section class="tool-section" id="tools">
-      <h2 class="section-title">navigation</h2>
-      <p class="section-note">Quick links into the writeups and tool dumps.</p>
+      <h2 class="section-title">writeups</h2>
+      <p class="section-note">Everything is collected in the public repository.</p>
       <div class="tool-grid">
-        <a class="tool-link" href="/osint.html">
+        <a class="tool-link" href="https://github.com/bopsec/ctf-writeups" target="_blank" rel="noopener">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🔎</span> osint</span>
-          </article>
-        </a>
-        <a class="tool-link" href="/ctf.html">
-          <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🕹️</span> ctf</span>
-          </article>
-        </a>
-        <a class="tool-link" href="/pentest.html">
-          <article class="tool-card">
-            <span class="tool-label"><span class="emoji">💥</span> pentest</span>
-          </article>
-        </a>
-        <a class="tool-link" href="/ai.html">
-          <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🤖</span> ai</span>
-          </article>
-        </a>
-        <a class="tool-link" href="/general.html">
-          <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🧰</span> general</span>
+            <span class="tool-label"><span class="emoji">📁</span> open the writeups repo</span>
           </article>
         </a>
       </div>
     </section>
   </main>
-
-  <script src="assets/theme-toggle.js" defer></script>
 </body>
 </html>

--- a/osint.html
+++ b/osint.html
@@ -6,60 +6,34 @@
   <title>bopsec</title>
   <link rel="stylesheet" href="assets/chillwave.css" />
 </head>
-<body class="mode-retro">
+<body class="mode-minimal">
   <main class="page-shell">
     <nav class="site-nav" aria-label="Primary">
       <div class="nav-links">
         <a class="nav-link" href="/index.html">home</a>
-        <a class="nav-link" href="/osint.html" aria-current="page">osint</a>
-        <a class="nav-link" href="/ctf.html">ctf</a>
-        <a class="nav-link" href="/pentest.html">pentest</a>
-        <a class="nav-link" href="/ai.html">ai</a>
-        <a class="nav-link" href="/general.html">general</a>
+        <a class="nav-link" href="https://github.com/bopsec/ctf-writeups" target="_blank" rel="noopener">writeups repo</a>
       </div>
-      <button class="mode-toggle" type="button" data-mode-toggle>light</button>
     </nav>
 
     <section class="hero">
       <div class="crt-panel">
         <h1 class="page-title">osint</h1>
-        <p class="deadpan">quiet scans.</p>
-        <p class="tagline">Recon and research notes without the flashing lights.</p>
+        <p class="deadpan">recon notes, in one place.</p>
+        <p class="tagline">OSINT threads and findings are mirrored in the same GitHub repository.</p>
       </div>
     </section>
 
     <section class="tool-section">
-      <h2 class="section-title">tools</h2>
-      <p class="section-note">uhhhh</p>
+      <h2 class="section-title">browse</h2>
+      <p class="section-note">Head straight to the repo to read or pull the notes.</p>
       <div class="tool-grid">
-        <a class="tool-link" href="https://picarta.ai" target="_blank" rel="noopener">
+        <a class="tool-link" href="https://github.com/bopsec/ctf-writeups" target="_blank" rel="noopener">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🖼</span> images</span>
-          </article>
-        </a>
-        <a class="tool-link" href="https://www.whoxy.com" target="_blank" rel="noopener">
-          <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🌐</span> whois</span>
-          </article>
-        </a>
-        <a class="tool-link" href="https://geospy.ai" target="_blank" rel="noopener">
-          <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🛰</span> geospy</span>
-          </article>
-        </a>
-        <a class="tool-link" href="https://crt.sh" target="_blank" rel="noopener">
-          <article class="tool-card">
-            <span class="tool-label"><span class="emoji">📜</span> certs</span>
+            <span class="tool-label"><span class="emoji">🔎</span> explore osint writeups</span>
           </article>
         </a>
       </div>
     </section>
-
-    <div class="back-link">
-      <a href="index.html">← back</a>
-    </div>
   </main>
-
-  <script src="assets/theme-toggle.js" defer></script>
 </body>
 </html>

--- a/pentest.html
+++ b/pentest.html
@@ -6,60 +6,34 @@
   <title>bopsec</title>
   <link rel="stylesheet" href="assets/chillwave.css" />
 </head>
-<body class="mode-retro">
+<body class="mode-minimal">
   <main class="page-shell">
     <nav class="site-nav" aria-label="Primary">
       <div class="nav-links">
         <a class="nav-link" href="/index.html">home</a>
-        <a class="nav-link" href="/osint.html">osint</a>
-        <a class="nav-link" href="/ctf.html">ctf</a>
-        <a class="nav-link" href="/pentest.html" aria-current="page">pentest</a>
-        <a class="nav-link" href="/ai.html">ai</a>
-        <a class="nav-link" href="/general.html">general</a>
+        <a class="nav-link" href="https://github.com/bopsec/ctf-writeups" target="_blank" rel="noopener">writeups repo</a>
       </div>
-      <button class="mode-toggle" type="button" data-mode-toggle>light</button>
     </nav>
 
     <section class="hero">
       <div class="crt-panel">
         <h1 class="page-title">pentest</h1>
-        <p class="deadpan">calm probes.</p>
-        <p class="tagline">Findings and methodology with a quieter backdrop.</p>
+        <p class="deadpan">notes where everyone can grab them.</p>
+        <p class="tagline">Methodology, findings, and commands sit alongside the CTF content in the repo.</p>
       </div>
     </section>
 
     <section class="tool-section">
-      <h2 class="section-title">tools</h2>
-      <p class="section-note">uhhhh</p>
+      <h2 class="section-title">read</h2>
+      <p class="section-note">The GitHub repo holds every pentest writeup.</p>
       <div class="tool-grid">
-        <a class="tool-link" href="https://github.com/hackerai-tech/PentestGPT" target="_blank" rel="noopener">
+        <a class="tool-link" href="https://github.com/bopsec/ctf-writeups" target="_blank" rel="noopener">
           <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🤖</span> pentestgpt</span>
-          </article>
-        </a>
-        <a class="tool-link" href="https://www.bugbountyhunting.com/" target="_blank" rel="noopener">
-          <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🕷</span> bug bounty</span>
-          </article>
-        </a>
-        <a class="tool-link" href="https://0dayfans.com/" target="_blank" rel="noopener">
-          <article class="tool-card">
-            <span class="tool-label"><span class="emoji">💣</span> 0dayfans</span>
-          </article>
-        </a>
-        <a class="tool-link" href="https://portswigger.net/web-security/sql-injection/cheat-sheet" target="_blank" rel="noopener">
-          <article class="tool-card">
-            <span class="tool-label"><span class="emoji">🧪</span> sqli sheet</span>
+            <span class="tool-label"><span class="emoji">💥</span> open pentest notes</span>
           </article>
         </a>
       </div>
     </section>
-
-    <div class="back-link">
-      <a href="index.html">← back</a>
-    </div>
   </main>
-
-  <script src="assets/theme-toggle.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update all main pages to direct visitors to the bopsec/ctf-writeups GitHub repository
- simplify styling to a single minimal dark theme and remove the retro/toggle options
- refresh copy so each section highlights the centralized writeup location

## Testing
- not run (static site)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d340b33a4832788c90813882f0af3)